### PR TITLE
Feature/#145751727/cancel an order

### DIFF
--- a/imports/plugins/core/checkout/client/templates/checkout/completed/completed.js
+++ b/imports/plugins/core/checkout/client/templates/checkout/completed/completed.js
@@ -11,7 +11,7 @@ import { Template } from "meteor/templating";
  */
 Template.cartCompleted.helpers({
   orderCompleted: function () {
-    const id =  Reaction.Router.getQueryParam("_id");
+    const id = Reaction.Router.getQueryParam("_id");
     if (id) {
       const ccoSub = Meteor.subscribe("CompletedCartOrder", Meteor.userId(), id);
       if (ccoSub.ready()) {
@@ -29,9 +29,12 @@ Template.cartCompleted.helpers({
   orderStatus: function () {
     if (this.workflow.status === "new") {
       return i18next.t("cartCompleted.submitted");
+    } else if (this.workflow.status === "canceled") {
+      return "Canceled";
     }
     return this.workflow.status;
   },
+
   userOrders: function () {
     if (Meteor.user()) {
       return Orders.find({

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -8,9 +8,12 @@ import { Orders, Shops } from "/lib/collections";
  */
 Template.dashboardOrdersList.helpers({
   orderStatus() {
-    if (this.workflow.status === "coreOrderCompleted") {
-      return true;
+    if (this.workflow.status === "coreOrderWorkflow/completed") {
+      return "completed";
+    } else if (this.workflow.status === "canceled") {
+      return "canceled";
     }
+    return "processing";
   },
   orders(data) {
     if (data.hash.data) {

--- a/imports/plugins/core/orders/client/templates/list/summary.html
+++ b/imports/plugins/core/orders/client/templates/list/summary.html
@@ -16,36 +16,36 @@
                 </div>
 
                 {{#if condition shipping 'gt' 0}}
-                <div class="row">
-                  <div class="col-xs-7 text-right">
-                    <span data-i18n='cartSubTotals.shipping'>Shipping</span>
+                  <div class="row">
+                    <div class="col-xs-7 text-right">
+                      <span data-i18n='cartSubTotals.shipping'>Shipping</span>
+                    </div>
+                    <div class="col-xs-4 col-xs-offset-1">
+                      {{> React (numericInputProps shipping)}}
+                    </div>
                   </div>
-                  <div class="col-xs-4 col-xs-offset-1">
-                    {{> React (numericInputProps shipping)}}
-                  </div>
-                </div>
                 {{/if}}
 
                 {{#if condition taxes 'gt' 0}}
-                <div class="row">
-                  <div class="col-xs-7 text-right">
-                    <span data-i18n='cartSubTotals.tax'>Tax</span>
+                  <div class="row">
+                    <div class="col-xs-7 text-right">
+                      <span data-i18n='cartSubTotals.tax'>Tax</span>
+                    </div>
+                    <div class="col-xs-4 col-xs-offset-1">
+                      {{> React (numericInputProps taxes)}}
+                    </div>
                   </div>
-                  <div class="col-xs-4 col-xs-offset-1">
-                    {{> React (numericInputProps taxes)}}
-                  </div>
-                </div>
                 {{/if}}
 
                 {{#if condition discounts 'gt' 0}}
-                <div class="row">
-                  <div class="col-xs-7 text-right">
-                    <span data-i18n='cartSubTotals.discount'>Discount</span>
+                  <div class="row">
+                    <div class="col-xs-7 text-right">
+                      <span data-i18n='cartSubTotals.discount'>Discount</span>
+                    </div>
+                    <div class="col-xs-4 col-xs-offset-1">
+                      {{> React (numericInputProps discounts)}}
+                    </div>
                   </div>
-                  <div class="col-xs-4 col-xs-offset-1">
-                    {{> React (numericInputProps discounts)}}
-                  </div>
-                </div>
                 {{/if}}
 
                 <div class="row">

--- a/imports/plugins/core/orders/client/templates/list/summary.html
+++ b/imports/plugins/core/orders/client/templates/list/summary.html
@@ -62,6 +62,11 @@
         {{/each}}
       </div>
     </div>
-
+    {{#if orderStatus}}
+      <div></div>
+    {{else}}
+      <div class="panel panel-default">
+        <button name="cancel" class="btn btn-sm btn-danger" type="submit" data-event-action="cancelOrder" data-i18n="order.cancelOrder">Cancel Order</button></div>
+    {{/if}}
   </div>
 </template>

--- a/imports/plugins/core/orders/client/templates/list/summary.html
+++ b/imports/plugins/core/orders/client/templates/list/summary.html
@@ -66,7 +66,7 @@
       <div></div>
     {{else}}
       <div class="panel panel-default">
-        <button name="cancel" class="btn btn-sm btn-danger" type="submit" data-event-action="cancelOrder" data-i18n="order.cancelOrder">Cancel Order</button></div>
+        <button name="cancel" class="btn btn-sm btn-danger" type="submit" data-event-action="order.cancelOrder" data-i18n="order.cancelOrder">Cancel Order</button></div>
     {{/if}}
   </div>
 </template>

--- a/imports/plugins/core/orders/client/templates/list/summary.js
+++ b/imports/plugins/core/orders/client/templates/list/summary.js
@@ -1,5 +1,6 @@
 import { Template } from "meteor/templating";
 import { NumericInput } from "/imports/plugins/core/ui/client/components";
+import swal from "sweetalert2";
 
 Template.ordersListSummary.onCreated(function () {
   this.state = new ReactiveDict();

--- a/imports/plugins/core/orders/client/templates/list/summary.js
+++ b/imports/plugins/core/orders/client/templates/list/summary.js
@@ -1,6 +1,16 @@
 import { Template } from "meteor/templating";
 import { NumericInput } from "/imports/plugins/core/ui/client/components";
 
+Template.ordersListSummary.onCreated(function () {
+  this.state = new ReactiveDict();
+
+  this.autorun(() => {
+    const currentData = Template.currentData();
+    const order = currentData.order;
+    this.state.set("order", order);
+  });
+});
+
 /**
  * ordersListSummary helpers
  *
@@ -20,5 +30,45 @@ Template.ordersListSummary.helpers({
       format: currencyFormat,
       isEditing: false
     };
+  },
+  displayCancelButton() {
+    return !(this.order.workflow.status === "canceled"
+      || this.order.workflow.status === "coreOrderWorkflow/canceled");
+  },
+
+  orderStatus() {
+    return this.order.workflow.status === "canceled";
   }
 });
+
+/**
+ * ordersListSummary events
+ */
+Template.ordersListSummary.events({
+  /**
+  * Submit form
+  * @param  {Event} event - Event object
+  * @param  {Template} instance - Blaze Template
+  * @return {void}
+  */
+  "click button[name=cancel]"(event, instance) {
+    event.stopPropagation();
+    const state = instance.state; const order = state.get("order");
+    swal({
+      title: "Are you sure?",
+      text: "You want to cancel the order placed!",
+      type: "warning",
+      showCancelButton: true,
+      confirmButtonClass: ".btn-danger",
+      confirmButtonText: "Yes!"
+    })
+      .then(() => {
+        Meteor.call("orders/cancelOrder", order, (error) => {
+          if (error) {
+            swal("Order cancellation unsuccesful.", "success");
+          }
+        });
+      });
+  }
+});
+

--- a/imports/plugins/core/orders/client/templates/orders.js
+++ b/imports/plugins/core/orders/client/templates/orders.js
@@ -13,9 +13,13 @@ const orderFilters = [{
 }, {
   name: "completed",
   label: "Completed"
-}];
+}, {
+  name: "canceled",
+  label: "canceled"
+}
+];
 
-const OrderHelper =  {
+const OrderHelper = {
   makeQuery(filter) {
     let query = {};
 
@@ -163,6 +167,10 @@ Template.ordersListItem.helpers({
 
   orderIsNew(order) {
     return order.workflow.status === "new";
+  },
+
+  isCanceled(order) {
+    return (order.workflow.status === "canceled");
   }
 });
 
@@ -223,7 +231,7 @@ Template.orderListFilters.onCreated(function () {
     this.subscribe("Orders");
 
     const filters = orderFilters.map((filter) => {
-      filter.label = i18next.t(`order.filter.${filter.name}`, {defaultValue: filter.label});
+      filter.label = i18next.t(`order.filter.${filter.name}`, { defaultValue: filter.label });
       filter.i18nKeyLabel = `order.filter.${filter.name}`;
       filter.count = Orders.find(OrderHelper.makeQuery(filter.name)).count();
 
@@ -301,6 +309,10 @@ Template.orderStatusDetail.helpers({
       return this.shipping[0].tracking;
     }
     return i18next.t("orderShipping.noTracking");
+  },
+
+  orderStatus: function () {
+    return this.workflow.status;
   },
 
   shipmentStatus() {

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -80,10 +80,10 @@ Meteor.methods({
         "_id": order._id,
         "shipping._id": shipment._id
       }, {
-        $set: {
-          "shipping.$.packed": packed
-        }
-      });
+          $set: {
+            "shipping.$.packed": packed
+          }
+        });
 
       // Set the status of the items as shipped
       const itemIds = shipment.items.map((item) => {
@@ -96,10 +96,10 @@ Meteor.methods({
           "_id": order._id,
           "shipping._id": shipment._id
         }, {
-          $set: {
-            "shipping.$.packed": packed
-          }
-        });
+            $set: {
+              "shipping.$.packed": packed
+            }
+          });
       }
       return result;
     }
@@ -210,6 +210,28 @@ Meteor.methods({
       }
     });
   },
+
+  /**
+   *
+   * @summary Cancel an Order
+   * @param {Object} order - order object
+   * @param {Object} newComment - new comment object
+   * @return {Object} return updated shipping results
+   */
+  "orders/cancelOrder"(order) {
+    check(order, Object);
+
+    // Update Order
+    return Orders.update(order._id, {
+      $set: {
+        "workflow.status": "canceled"
+      },
+      $addToSet: {
+        "workflow.workflow": "coreOrderWorkflow/canceled"
+      }
+    });
+  },
+
   /**
    * orders/shipmentShipped
    *
@@ -436,7 +458,7 @@ Meteor.methods({
       from: `${shop.name} <${shop.emails[0].address}>`,
       subject: `Your order is confirmed`,
       // subject: `Order update from ${shop.name}`,
-      html: SSR.render(tpl,  dataForOrderEmail)
+      html: SSR.render(tpl, dataForOrderEmail)
     });
 
     return true;
@@ -490,10 +512,10 @@ Meteor.methods({
       "_id": orderId,
       "shipping._id": shippingId
     }, {
-      $addToSet: {
-        "shipping.shipments": data
-      }
-    });
+        $addToSet: {
+          "shipping.shipments": data
+        }
+      });
   },
 
   /**
@@ -518,10 +540,10 @@ Meteor.methods({
       "_id": order._id,
       "shipping._id": shipment._id
     }, {
-      $set: {
-        ["shipping.$.tracking"]: tracking
-      }
-    });
+        $set: {
+          ["shipping.$.tracking"]: tracking
+        }
+      });
   },
 
   /**
@@ -546,10 +568,10 @@ Meteor.methods({
       "_id": orderId,
       "shipping._id": shipmentId
     }, {
-      $push: {
-        "shipping.$.items": item
-      }
-    });
+        $push: {
+          "shipping.$.items": item
+        }
+      });
   },
 
   "orders/updateShipmentItem": function (orderId, shipmentId, item) {
@@ -565,10 +587,10 @@ Meteor.methods({
       "_id": orderId,
       "shipments._id": shipmentId
     }, {
-      $addToSet: {
-        "shipment.$.items": shipmentIndex
-      }
-    });
+        $addToSet: {
+          "shipment.$.items": shipmentIndex
+        }
+      });
   },
 
   /**
@@ -619,7 +641,7 @@ Meteor.methods({
       throw new Meteor.Error(403, "Access Denied. You are not connected.");
     }
 
-    return Orders.update({cartId: cartId}, {
+    return Orders.update({ cartId: cartId }, {
       $set: {
         email: email
       }
@@ -699,10 +721,10 @@ Meteor.methods({
       Products.update({
         _id: item.variants._id
       }, {
-        $inc: {
-          inventoryQuantity: -item.quantity
-        }
-      }, { selector: { type: "variant" } });
+          $inc: {
+            inventoryQuantity: -item.quantity
+          }
+        }, { selector: { type: "variant" } });
     });
   },
 
@@ -746,15 +768,15 @@ Meteor.methods({
               "_id": orderId,
               "billing.paymentMethod.transactionId": transactionId
             }, {
-              $set: {
-                "billing.$.paymentMethod.mode": "capture",
-                "billing.$.paymentMethod.status": "completed",
-                "billing.$.paymentMethod.metadata": metadata
-              },
-              $push: {
-                "billing.$.paymentMethod.transactions": result
-              }
-            });
+                $set: {
+                  "billing.$.paymentMethod.mode": "capture",
+                  "billing.$.paymentMethod.status": "completed",
+                  "billing.$.paymentMethod.metadata": metadata
+                },
+                $push: {
+                  "billing.$.paymentMethod.transactions": result
+                }
+              });
           } else {
             if (result && result.error) {
               Logger.fatal("Failed to capture transaction.", order, paymentMethod.transactionId, result.error);
@@ -766,16 +788,16 @@ Meteor.methods({
               "_id": orderId,
               "billing.paymentMethod.transactionId": transactionId
             }, {
-              $set: {
-                "billing.$.paymentMethod.mode": "capture",
-                "billing.$.paymentMethod.status": "error"
-              },
-              $push: {
-                "billing.$.paymentMethod.transactions": result
-              }
-            });
+                $set: {
+                  "billing.$.paymentMethod.mode": "capture",
+                  "billing.$.paymentMethod.status": "error"
+                },
+                $push: {
+                  "billing.$.paymentMethod.transactions": result
+                }
+              });
 
-            return {error: "orders/capturePayments: Failed to capture transaction"};
+            return { error: "orders/capturePayments: Failed to capture transaction" };
           }
         });
       }
@@ -839,10 +861,10 @@ Meteor.methods({
       "_id": orderId,
       "billing.paymentMethod.transactionId": transactionId
     }, {
-      $push: {
-        "billing.$.paymentMethod.transactions": result
-      }
-    });
+        $push: {
+          "billing.$.paymentMethod.transactions": result
+        }
+      });
 
     if (result.saved === false) {
       Logger.fatal("Attempt for refund transaction failed", order._id, paymentMethod.transactionId, result.error);


### PR DESCRIPTION
**What does this PR do?**

Adds a cancel order option to both Admin and Guest user

**Description of Task to be completed?**

Add "cancel order" option.

**How should this be manually tested?**
-Login as an admin or guest user.
-Make an order.
-Choose payment provider.
-To cancel before shipment, click on the cancel button to cancel your order.
-A pop up will appear to a certain your cancellation, if clicked yes your order will be cancelled hence order status will be changed to cancelled.


**What are the relevant pivotal tracker stories?**

#145751727

**Screenshots (if appropriate)**

This is the page to cancel an order after an order has been completed.

<img width="1195" alt="screen shot 2017-05-31 at 8 03 26 am" src="https://cloud.githubusercontent.com/assets/27012452/26616536/1adb685e-45d8-11e7-9954-ce2098323152.png">

This is the pop up alert that asserts your order cancellation.

<img width="588" alt="screen shot 2017-05-31 at 8 03 39 am" src="https://cloud.githubusercontent.com/assets/27012452/26616578/53aaf0fa-45d8-11e7-9139-722d0f6ae1c5.png">

This is the status change that shows your order is canceled.

<img width="1215" alt="screen shot 2017-05-31 at 8 03 52 am" src="https://cloud.githubusercontent.com/assets/27012452/26616589/70df8e6a-45d8-11e7-90ae-eb1f4bf982e3.png">
